### PR TITLE
Fix lint errors

### DIFF
--- a/lib/binding.js
+++ b/lib/binding.js
@@ -1197,37 +1197,42 @@ Binding.prototype.lstat = function(filepath, options, callback) {
  * @param {function(Error)} callback Callback (optional).
  */
 Binding.prototype.access = function(filepath, mode, callback, ctx) {
-  maybeCallback(normalizeCallback(callback), this, function() {
-    var item = this._system.getItem(filepath);
-    var links = 0;
-    while (item instanceof SymbolicLink) {
-      if (links > MAX_LINKS) {
-        throw new FSError('ELOOP', filepath);
+  maybeCallback(
+    normalizeCallback(callback),
+    this,
+    function() {
+      var item = this._system.getItem(filepath);
+      var links = 0;
+      while (item instanceof SymbolicLink) {
+        if (links > MAX_LINKS) {
+          throw new FSError('ELOOP', filepath);
+        }
+        filepath = path.resolve(path.dirname(filepath), item.getPath());
+        item = this._system.getItem(filepath);
+        ++links;
       }
-      filepath = path.resolve(path.dirname(filepath), item.getPath());
-      item = this._system.getItem(filepath);
-      ++links;
-    }
-    if (!item) {
-      throw new FSError('ENOENT', filepath);
-    }
-    if (mode && process.getuid && process.getgid) {
-      var itemMode = item.getMode();
-      if (item.getUid() === process.getuid()) {
-        if ((itemMode & (mode * 64)) !== mode * 64) {
-          throw new FSError('EACCES', filepath);
-        }
-      } else if (item.getGid() === process.getgid()) {
-        if ((itemMode & (mode * 8)) !== mode * 8) {
-          throw new FSError('EACCES', filepath);
-        }
-      } else {
-        if ((itemMode & mode) !== mode) {
-          throw new FSError('EACCES', filepath);
+      if (!item) {
+        throw new FSError('ENOENT', filepath);
+      }
+      if (mode && process.getuid && process.getgid) {
+        var itemMode = item.getMode();
+        if (item.getUid() === process.getuid()) {
+          if ((itemMode & (mode * 64)) !== mode * 64) {
+            throw new FSError('EACCES', filepath);
+          }
+        } else if (item.getGid() === process.getgid()) {
+          if ((itemMode & (mode * 8)) !== mode * 8) {
+            throw new FSError('EACCES', filepath);
+          }
+        } else {
+          if ((itemMode & mode) !== mode) {
+            throw new FSError('EACCES', filepath);
+          }
         }
       }
-    }
-  }, ctx);
+    },
+    ctx
+  );
 };
 
 /**


### PR DESCRIPTION
Fixes the lint errors that broke the Travis build [https://travis-ci.org/tschaub/mock-fs/jobs/478476711](https://travis-ci.org/tschaub/mock-fs/jobs/478476711).
10 test cases still fail though for `fs.mkdir` and `fs.createWriteStream`.